### PR TITLE
DebugLevel variable in reference scripts

### DIFF
--- a/tests/referenceScripts/BuiltInExample1/pythonScript.py
+++ b/tests/referenceScripts/BuiltInExample1/pythonScript.py
@@ -128,7 +128,8 @@ tTKPersistenceCurve1 = TTKPersistenceCurve(Input=tetrahedralize1)
 tTKPersistenceCurve1.ScalarField = 'myVorticity'
 tTKPersistenceCurve1.InputOffsetField = ''
 
-# ----------------------------------------------------------------tTKScalarFieldNormalizer1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKScalarFieldNormalizer1.DebugLevel = int(debugLevel)
 if tTKScalarFieldNormalizer1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKScalarFieldNormalizer1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKScalarFieldNormalizer1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/BuiltInExample3/pythonScript.py
+++ b/tests/referenceScripts/BuiltInExample3/pythonScript.py
@@ -216,7 +216,8 @@ transform1.Transform = 'Transform'
 # init the 'Transform' selected for 'Transform'
 transform1.Transform.Translate = [0.0, 0.0, 0.0001]
 
-# ----------------------------------------------------------------tTKPersistenceDiagram2.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKPersistenceDiagram2.DebugLevel = int(debugLevel)
 if tTKPersistenceDiagram2.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKPersistenceDiagram2.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKPersistenceDiagram2_' + str(i) + '.vtu',

--- a/tests/referenceScripts/bivariateToyCspPeeling/pythonScript.py
+++ b/tests/referenceScripts/bivariateToyCspPeeling/pythonScript.py
@@ -172,7 +172,8 @@ tube3.Scalars = ['POINTS', 'v']
 tube3.Vectors = [None, '']
 tube3.Radius = 0.015
 
-# ----------------------------------------------------------------tTKContinuousScatterPlot1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKContinuousScatterPlot1.DebugLevel = int(debugLevel)
 if tTKContinuousScatterPlot1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKContinuousScatterPlot1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKContinuousScatterPlot1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/ctBones/pythonScript.py
+++ b/tests/referenceScripts/ctBones/pythonScript.py
@@ -110,7 +110,8 @@ tube2.Radius = 1.5
 tTKSphereFromPoint1 = TTKSphereFromPoint(Input=persistenceThreshold)
 tTKSphereFromPoint1.Radius = 5.0
 
-# ----------------------------------------------------------------tTKPersistenceDiagram1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKPersistenceDiagram1.DebugLevel = int(debugLevel)
 if tTKPersistenceDiagram1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKPersistenceDiagram1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKPersistenceDiagram1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/manifoldChecks/pythonScript.py
+++ b/tests/referenceScripts/manifoldChecks/pythonScript.py
@@ -135,7 +135,8 @@ threshold1 = Threshold(Input=tTKSphereFromPoint2)
 threshold1.Scalars = ['POINTS', 'VertexLinkComponentNumber']
 threshold1.ThresholdRange = [2.0, 2.0]
 
-# ----------------------------------------------------------------tTKManifoldCheck3.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKManifoldCheck3.DebugLevel = int(debugLevel)
 if tTKManifoldCheck3.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKManifoldCheck3.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKManifoldCheck3_' + str(i) + '.vtu',

--- a/tests/referenceScripts/mechanical/pythonScript.py
+++ b/tests/referenceScripts/mechanical/pythonScript.py
@@ -196,7 +196,8 @@ extractSurface5 = ExtractSurface(Input=a3sheetIdselectionthreshold)
 tTKGeometrySmoother1 = TTKGeometrySmoother(Input=extractSurface5)
 tTKGeometrySmoother1.IterationNumber = 2
 
-# ----------------------------------------------------------------tTKReebSpace1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKReebSpace1.DebugLevel = int(debugLevel)
 if tTKReebSpace1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKReebSpace1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKReebSpace1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/morseMolecule/pythonScript.py
+++ b/tests/referenceScripts/morseMolecule/pythonScript.py
@@ -204,7 +204,8 @@ contour1.ComputeScalars = 1
 contour1.Isosurfaces = [1.0]
 contour1.PointMergeMethod = 'Uniform Binning'
 
-# ----------------------------------------------------------------tTKMorseSmaleComplex1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKMorseSmaleComplex1.DebugLevel = int(debugLevel)
 if tTKMorseSmaleComplex1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKMorseSmaleComplex1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKMorseSmaleComplex1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/morsePersistence/pythonScript.py
+++ b/tests/referenceScripts/morsePersistence/pythonScript.py
@@ -152,7 +152,8 @@ tube3.Scalars = ['POINTS', 'CellDimension']
 tube3.Vectors = [None, '']
 tube3.Radius = 0.005
 
-# ----------------------------------------------------------------tTKScalarFieldSmoother1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKScalarFieldSmoother1.DebugLevel = int(debugLevel)
 if tTKScalarFieldSmoother1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKScalarFieldSmoother1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKScalarFieldSmoother1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/tectonicPuzzle/pythonScript.py
+++ b/tests/referenceScripts/tectonicPuzzle/pythonScript.py
@@ -240,7 +240,8 @@ extractSurface5 = ExtractSurface(Input=cleantoGrid2)
 # create a new 'Generate Surface Normals'
 generateSurfaceNormals1 = GenerateSurfaceNormals(Input=extractSurface5)
 
-# ----------------------------------------------------------------tTKPersistenceDiagram1.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKPersistenceDiagram1.DebugLevel = int(debugLevel)
 if tTKPersistenceDiagram1.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKPersistenceDiagram1.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKPersistenceDiagram1_' + str(i) + '.vtu',

--- a/tests/referenceScripts/uncertainStartingVortex/pythonScript.py
+++ b/tests/referenceScripts/uncertainStartingVortex/pythonScript.py
@@ -187,7 +187,8 @@ tube1.Scalars = ['POINTS', 'NodeType']
 tube1.Vectors = [None, '']
 tube1.Radius = 0.015
 
-# ----------------------------------------------------------------tTKPersistenceDiagram2.DebugLevel = int(debugLevel)
+# ----------------------------------------------------------------
+tTKPersistenceDiagram2.DebugLevel = int(debugLevel)
 if tTKPersistenceDiagram2.GetNumberOfOutputPorts() != 1:
 	for i in range(0, tTKPersistenceDiagram2.GetNumberOfOutputPorts()):
 		SaveData(outputDirectory + 'tTKPersistenceDiagram2_' + str(i) + '.vtu',


### PR DESCRIPTION
Dear Julien,

I found in some reference scripts comments of TTK modules supposed to set the given value of `debugLevel`. This PR uncomments the corresponding lines of code.