### PR TITLE
morseMolecule: Fix threshold bound

### DIFF
--- a/states/morseMolecule.pvsm
+++ b/states/morseMolecule.pvsm
@@ -58438,8 +58438,8 @@
         </Domain>
       </Property>
       <Property name="ThresholdBetween" id="8030.ThresholdBetween" number_of_elements="2">
-        <Element index="0" value="0"/>
-        <Element index="1" value="0"/>
+        <Element index="0" value="1"/>
+        <Element index="1" value="1"/>
         <Domain name="range" id="8030.ThresholdBetween.range"/>
       </Property>
       <Property name="UseContinuousCellRange" id="8030.UseContinuousCellRange" number_of_elements="1">


### PR DESCRIPTION
Due to https://github.com/topology-tool-kit/ttk/pull/616, the selected saddle connectors have now 1 critical point on their boundary. This PR fixes the threshold to select the correct saddle connectors (segfault in GeometrySmoother's ExplicitTriangulation preconditioning due to an empty dataset without)

Enjoy,
Pierre