### PR TITLE
Remove identical screenshots

### DIFF
--- a/tests/validate.py
+++ b/tests/validate.py
@@ -72,6 +72,9 @@ def main(gen_ref=False, only_comp=False):
             if not ident:
                 print(f"Error for {img.name}: {err}")
                 passed = False
+            elif not only_comp:
+                # keep only the modified screenshots
+                out_im.unlink()
 
         if passed:
             print("Validation passed!")

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -39,7 +39,7 @@ def compare_screenshots(png0, png1, threshold):
     return (True, err)
 
 
-def main(gen_ref=False, only_comp=False):
+def main(gen_ref=False, only_comp=False, keep_identical=False):
     # change working directory to ttk-data root folder
     p = pathlib.Path(os.path.realpath(__file__)).parents[1]
     os.chdir(p)
@@ -72,7 +72,7 @@ def main(gen_ref=False, only_comp=False):
             if not ident:
                 print(f"Error for {img.name}: {err}")
                 passed = False
-            elif not only_comp:
+            elif not keep_identical:
                 # keep only the modified screenshots
                 out_im.unlink()
 
@@ -96,6 +96,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Only compare already generated screenshots",
     )
+    parser.add_argument(
+        "-k",
+        "--keep_identical",
+        action="store_true",
+        help="Keep generated screenshots that are identical to reference",
+    )
     args = parser.parse_args()
 
-    main(args.generate_reference, args.only_compare)
+    main(args.generate_reference, args.only_compare, args.keep_identical)


### PR DESCRIPTION
This PR improves the `tests/validate.py` script to remove by default generated screenshots that are identical to the reference ones. By removing identical screenshots, it is easier to compare differences, for instance with imagemagick.

A new command-line flag , `-k`/`--keep_identical` has been introduced to go back to the original behavior.

Enjoy,
Pierre