### PR TITLE
Document Morse-Smale Quadrangulation example

### DIFF
--- a/docs/morseSmaleQuadrangulation.md
+++ b/docs/morseSmaleQuadrangulation.md
@@ -1,0 +1,76 @@
+# Morse-Smale Quandrangulation example
+
+<!--[![Morse-Smale Quadrangulation example video tutorial](https://topology-tool-kit.github.io/img/gallery/morseSmaleQuadrangulation.jpg)](https://www.youtube.com/watch?v=eNW8l5PlgpU)-->
+
+<iframe width="100%" height="420"
+src="https://www.youtube.com/embed/eNW8l5PlgpU" frameborder="0"
+allowfullscreen></iframe>
+
+## Pipeline description
+
+This example first loads a mecanical model as a 2D triangle mesh from
+disk. This mechanical model embeds a vector field with the output of
+the
+[EigenField](https://topology-tool-kit.github.io/doc/html/classttkEigenField.html)
+module. This module generated a family of functions that are coupled
+to the form of the dataset (basically, they are eigenfunctions of the
+laplacian matrix of the triangulation, sorted by decreasing eigenvalue
+magnitude).
+
+In a pre-processing step, the 83rd EigenFunction is extracted and
+normalized with
+[ScalarFieldNormalizer](https://topology-tool-kit.github.io/doc/html/classttkScalarFieldNormalizer.html)
+then simplified using
+[PersistenceDiagram](https://topology-tool-kit.github.io/doc/html/classttkPersistenceDiagram.html)
+and
+[TopologicalSimplification](https://topology-tool-kit.github.io/doc/html/classttkTopologicalSimplification.html).
+
+We then compute the
+[MorseSmaleComplex](https://topology-tool-kit.github.io/doc/html/classttkMorseSmaleComplex.html)
+of the simplified scalar field. The critical points are evenly spread
+onto the 2D surface and the 1-separatrices will form the base of the
+quadrangulation (left view on the above screenshot).
+
+The filter
+[MorseSmaleQuadrangulation](https://topology-tool-kit.github.io/doc/html/classttkMorseSmaleQuadrangulation.html)
+creates a coarse quadrangulation of the input mesh using the
+Morse-Smale complex critical points and 1-separatrices.
+
+This coarse quadrangulation is eventually refined with the
+[QuadrangulationSubdivision](https://topology-tool-kit.github.io/doc/html/classttkQuadrangulationSubdivision.html)
+filter (right view on the above screenshot).
+
+## ParaView
+To reproduce the above screenshot, go to your [ttk-data](https://github.com/topology-tool-kit/ttk-data) directory and enter the following command:
+``` bash
+$ paraview states/morseSmaleQuadrangulation.pvsm
+```
+
+## Python code
+
+``` python  linenums="1"
+--8<-- "python/morseSmaleQuadrangulation.py"
+```
+
+## Inputs
+- [rockerArm.vtu](https://github.com/topology-tool-kit/ttk-data/raw/dev/rockerArm.vtu): a two-dimensional triangulated mechanical model.
+
+## Outputs
+- `Quadrangulation.vtp`: the output quadrangulated surface.
+
+
+## C++/Python API
+
+[EigenField](https://topology-tool-kit.github.io/doc/html/classttkEigenField.html)
+
+[ScalarFieldNormalizer](https://topology-tool-kit.github.io/doc/html/classttkScalarFieldNormalizer.html)
+
+[PersistenceDiagram](https://topology-tool-kit.github.io/doc/html/classttkPersistenceDiagram.html)
+
+[TopologicalSimplification](https://topology-tool-kit.github.io/doc/html/classttkTopologicalSimplification.html)
+
+[MorseSmaleComplex](https://topology-tool-kit.github.io/doc/html/classttkMorseSmaleComplex.html)
+
+[MorseSmaleQuadrangulation](https://topology-tool-kit.github.io/doc/html/classttkMorseSmaleQuadrangulation.html)
+
+[QuadrangulationSubdivision](https://topology-tool-kit.github.io/doc/html/classttkQuadrangulationSubdivision.html)

--- a/docs/morseSmaleQuadrangulation.md
+++ b/docs/morseSmaleQuadrangulation.md
@@ -9,8 +9,8 @@ allowfullscreen></iframe>
 ## Pipeline description
 
 This example first loads a mecanical model as a 2D triangle mesh from
-disk. This mechanical model embeds a vector field with the output of
-the
+disk. This mechanical model embeds a collection of scalar fields that
+corresponds to the output of the
 [EigenField](https://topology-tool-kit.github.io/doc/html/classttkEigenField.html)
 module. This module generated a family of functions that are coupled
 to the form of the dataset (basically, they are eigenfunctions of the

--- a/python/morseSmaleQuadrangulation.py
+++ b/python/morseSmaleQuadrangulation.py
@@ -4,7 +4,6 @@ from paraview.simple import *
 
 # create a new 'XML Unstructured Grid Reader'
 rockerArmvtu = XMLUnstructuredGridReader(FileName=["rockerArm.vtu"])
-rockerArmvtu.PointArrayStatus = ["OutputEigenFunctions"]
 
 # create a new 'Extract Component'
 extractComponent1 = ExtractComponent(Input=rockerArmvtu)
@@ -18,7 +17,6 @@ tTKScalarFieldNormalizer1.ScalarField = ["POINTS", "Result"]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=tTKScalarFieldNormalizer1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "Result"]
-tTKPersistenceDiagram1.InputOffsetField = [None, ""]
 tTKPersistenceDiagram1.EmbedinDomain = 1
 
 # create a new 'Threshold'
@@ -31,48 +29,14 @@ tTKTopologicalSimplification1 = TTKTopologicalSimplification(
     Domain=tTKScalarFieldNormalizer1, Constraints=threshold1
 )
 tTKTopologicalSimplification1.ScalarField = ["POINTS", "Result"]
-tTKTopologicalSimplification1.InputOffsetField = [None, ""]
-tTKTopologicalSimplification1.VertexIdentifierField = [None, ""]
 
 # create a new 'TTK MorseSmaleComplex'
 tTKMorseSmaleComplex1 = TTKMorseSmaleComplex(Input=tTKTopologicalSimplification1)
 tTKMorseSmaleComplex1.ScalarField = ["POINTS", "Result"]
-tTKMorseSmaleComplex1.OffsetField = ["POINTS", "Result"]
-
-# create a new 'TTK IdentifierRandomizer'
-tTKIdentifierRandomizer1 = TTKIdentifierRandomizer(
-    registrationName="TTKIdentifierRandomizer1",
-    Input=OutputPort(tTKMorseSmaleComplex1, 3),
-)
-tTKIdentifierRandomizer1.ScalarField = ["POINTS", "MorseSmaleManifold"]
-
-# create a new 'Extract Surface'
-extractSurface2 = ExtractSurface(Input=tTKIdentifierRandomizer1)
-
-# create a new 'TTK IcospheresFromPoints'
-tTKIcospheresFromPoints1 = TTKIcospheresFromPoints(Input=tTKMorseSmaleComplex1)
-tTKIcospheresFromPoints1.Radius = 0.01
-
-# create a new 'TTK GeometrySmoother'
-tTKGeometrySmoother1 = TTKGeometrySmoother(Input=OutputPort(tTKMorseSmaleComplex1, 1))
-tTKGeometrySmoother1.IterationNumber = 5
-tTKGeometrySmoother1.InputMaskField = [None, ""]
-
-# create a new 'Extract Surface'
-extractSurface1 = ExtractSurface(Input=tTKGeometrySmoother1)
-
-# create a new 'Tube'
-tube1 = Tube(Input=extractSurface1)
-tube1.Scalars = ["POINTS", "CellDimension"]
-tube1.Vectors = [None, ""]
-tube1.Radius = 0.004
-
-# create a new 'Generate Surface Normals'
-generateSurfaceNormals1 = GenerateSurfaceNormals(Input=extractSurface2)
 
 # create a new 'TTK MorseSmaleQuadrangulation'
 tTKMorseSmaleQuadrangulation1 = TTKMorseSmaleQuadrangulation(
-    Triangulatedsurface=tTKIdentifierRandomizer1,
+    Triangulatedsurface=OutputPort(tTKMorseSmaleComplex1, 3),
     MorseSmalecriticalpoints=tTKMorseSmaleComplex1,
     MorseSmale1separatrices=OutputPort(tTKMorseSmaleComplex1, 1),
 )
@@ -87,11 +51,5 @@ tTKQuadrangulationSubdivision1 = TTKQuadrangulationSubdivision(
 tTKQuadrangulationSubdivision1.Levelofsubdivisions = 3
 tTKQuadrangulationSubdivision1.Numberofrelaxationiterations = 100
 
-# create a new 'Extract Surface'
-extractSurface3 = ExtractSurface(Input=tTKQuadrangulationSubdivision1)
-
-# create a new 'Generate Surface Normals'
-generateSurfaceNormals2 = GenerateSurfaceNormals(Input=extractSurface3)
-
 # save the output
-SaveData("Quadrangulation.vtp", generateSurfaceNormals2)
+SaveData("Quadrangulation.vtp", tTKQuadrangulationSubdivision1)

--- a/python/morseSmaleQuadrangulation.py
+++ b/python/morseSmaleQuadrangulation.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+from paraview.simple import *
+
+# create a new 'XML Unstructured Grid Reader'
+rockerArmvtu = XMLUnstructuredGridReader(FileName=["rockerArm.vtu"])
+rockerArmvtu.PointArrayStatus = ["OutputEigenFunctions"]
+
+# create a new 'Extract Component'
+extractComponent1 = ExtractComponent(Input=rockerArmvtu)
+extractComponent1.InputArray = ["POINTS", "OutputEigenFunctions"]
+extractComponent1.Component = 83
+
+# create a new 'TTK ScalarFieldNormalizer'
+tTKScalarFieldNormalizer1 = TTKScalarFieldNormalizer(Input=extractComponent1)
+tTKScalarFieldNormalizer1.ScalarField = ["POINTS", "Result"]
+
+# create a new 'TTK PersistenceDiagram'
+tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=tTKScalarFieldNormalizer1)
+tTKPersistenceDiagram1.ScalarField = ["POINTS", "Result"]
+tTKPersistenceDiagram1.InputOffsetField = [None, ""]
+tTKPersistenceDiagram1.EmbedinDomain = 1
+
+# create a new 'Threshold'
+threshold1 = Threshold(Input=tTKPersistenceDiagram1)
+threshold1.Scalars = ["CELLS", "Persistence"]
+threshold1.ThresholdRange = [0.001, 0.9999999403953552]
+
+# create a new 'TTK TopologicalSimplification'
+tTKTopologicalSimplification1 = TTKTopologicalSimplification(
+    Domain=tTKScalarFieldNormalizer1, Constraints=threshold1
+)
+tTKTopologicalSimplification1.ScalarField = ["POINTS", "Result"]
+tTKTopologicalSimplification1.InputOffsetField = [None, ""]
+tTKTopologicalSimplification1.VertexIdentifierField = [None, ""]
+
+# create a new 'TTK MorseSmaleComplex'
+tTKMorseSmaleComplex1 = TTKMorseSmaleComplex(Input=tTKTopologicalSimplification1)
+tTKMorseSmaleComplex1.ScalarField = ["POINTS", "Result"]
+tTKMorseSmaleComplex1.OffsetField = ["POINTS", "Result"]
+
+# create a new 'TTK IdentifierRandomizer'
+tTKIdentifierRandomizer1 = TTKIdentifierRandomizer(
+    registrationName="TTKIdentifierRandomizer1",
+    Input=OutputPort(tTKMorseSmaleComplex1, 3),
+)
+tTKIdentifierRandomizer1.ScalarField = ["POINTS", "MorseSmaleManifold"]
+
+# create a new 'Extract Surface'
+extractSurface2 = ExtractSurface(Input=tTKIdentifierRandomizer1)
+
+# create a new 'TTK IcospheresFromPoints'
+tTKIcospheresFromPoints1 = TTKIcospheresFromPoints(Input=tTKMorseSmaleComplex1)
+tTKIcospheresFromPoints1.Radius = 0.01
+
+# create a new 'TTK GeometrySmoother'
+tTKGeometrySmoother1 = TTKGeometrySmoother(Input=OutputPort(tTKMorseSmaleComplex1, 1))
+tTKGeometrySmoother1.IterationNumber = 5
+tTKGeometrySmoother1.InputMaskField = [None, ""]
+
+# create a new 'Extract Surface'
+extractSurface1 = ExtractSurface(Input=tTKGeometrySmoother1)
+
+# create a new 'Tube'
+tube1 = Tube(Input=extractSurface1)
+tube1.Scalars = ["POINTS", "CellDimension"]
+tube1.Vectors = [None, ""]
+tube1.Radius = 0.004
+
+# create a new 'Generate Surface Normals'
+generateSurfaceNormals1 = GenerateSurfaceNormals(Input=extractSurface2)
+
+# create a new 'TTK MorseSmaleQuadrangulation'
+tTKMorseSmaleQuadrangulation1 = TTKMorseSmaleQuadrangulation(
+    Triangulatedsurface=tTKIdentifierRandomizer1,
+    MorseSmalecriticalpoints=tTKMorseSmaleComplex1,
+    MorseSmale1separatrices=OutputPort(tTKMorseSmaleComplex1, 1),
+)
+tTKMorseSmaleQuadrangulation1.DualQuadrangulation = 1
+
+# create a new 'TTK QuadrangulationSubdivision'
+tTKQuadrangulationSubdivision1 = TTKQuadrangulationSubdivision(
+    registrationName="TTKQuadrangulationSubdivision1",
+    Triangulatedsurface=OutputPort(tTKMorseSmaleComplex1, 3),
+    Coarsequadrangulation=tTKMorseSmaleQuadrangulation1,
+)
+tTKQuadrangulationSubdivision1.Levelofsubdivisions = 3
+tTKQuadrangulationSubdivision1.Numberofrelaxationiterations = 100
+
+# create a new 'Extract Surface'
+extractSurface3 = ExtractSurface(Input=tTKQuadrangulationSubdivision1)
+
+# create a new 'Generate Surface Normals'
+generateSurfaceNormals2 = GenerateSurfaceNormals(Input=extractSurface3)
+
+# save the output
+SaveData("Quadrangulation.vtp", generateSurfaceNormals2)


### PR DESCRIPTION
This PR adds a simple Python script and a mkdocs file to document the ttk-data  MorseSmaleQuadrangulation state file. 

Enjoy,
Pierre