### PR TITLE
Document the persistenceDrivenCompression example

### DIFF
--- a/docs/persistenceDrivenCompression.md
+++ b/docs/persistenceDrivenCompression.md
@@ -60,7 +60,9 @@ This script only loads the compressed data-sets.
 
 ## Outputs
 
-None for this state file.
+* `uncompressed_naturalImage_zfp50.vti`: the second input saved as a VTI file.
+* `uncompressed_naturalImage_persistence10.vti`: the third input saved as a VTI file.
+* `uncompressed_naturalImage_persistence10_zfp50.vti`: the last input saved as a VTI file.
 
 ## C++/Python API
 

--- a/docs/persistenceDrivenCompression.md
+++ b/docs/persistenceDrivenCompression.md
@@ -1,0 +1,71 @@
+# Persistence-Driven Compression example
+
+![Persistence-Driven Compression example
+Image](https://topology-tool-kit.github.io/img/gallery/persistenceDrivenCompression.jpg)
+
+## Pipeline description
+
+This example helps comparing three outputs of the
+[TopologicalCompression](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompression.html)
+filter to the original input grayscale image (top-left view in the above
+screenshot), with the following parameters:
+
+- ZFP relative error tolerance set to 50%, no topological compression
+  (bottom-left view in the above screenshot),
+- Topological loss set to 10%, no ZFP extra compression (top-right view),
+- Topological loss set to 10% and ZFP relative error tolerance set to 50% (bottom-right view).
+
+Those files have been generated from the original VTI image using the
+[TopologicalCompressionWriter](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompressionWriter.html)
+filter. To read them, Paraview uses its counterpart,
+[TopologicalCompressionReader](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompressionWriter.html).
+
+## ParaView
+
+To reproduce the above screenshot, go to your
+[ttk-data](https://github.com/topology-tool-kit/ttk-data) directory
+and enter the following command:
+
+``` bash
+$ paraview states/persistenceDrivenCompression.pvsm
+```
+
+## Python code
+
+This script only loads the compressed data-sets.
+
+``` python  linenums="1"
+--8<-- "python/persistenceDrivenCompression.py"
+```
+
+## Inputs
+
+- [naturalImage_original.vti](https://github.com/topology-tool-kit/ttk-data/raw/dev/naturalImage_original.vti):
+  a grayscale picture converted to the VTI format
+
+- [naturalImage_zpf50.ttk](https://github.com/topology-tool-kit/ttk-data/raw/dev/naturalImage_zfp50.ttk):
+  the previous image, compressed using `TopologicalCompressionWriter`
+  with ZFP compressor only (no topological compression). ZFP relative
+  error tolerance was set to 50%.
+
+- [naturalImage_persistence10.ttk](https://github.com/topology-tool-kit/ttk-data/raw/dev/naturalImage_persistence10.ttk):
+  the first input image, compressed using
+  `TopologicalCompressionWriter` with a Topological loss of 10% and
+  without ZFP (ZFP relative error tolerance set to a negative value).
+
+- [naturalImage_persistence10_zpf50.ttk](https://github.com/topology-tool-kit/ttk-data/raw/dev/naturalImage_persistence10_zfp50.ttk):
+  the first input image, compressed using
+  `TopologicalCompressionWriter` with a Topological loss of 10% and a
+  ZFP relative error tolerance set to 50%.
+
+## Outputs
+
+None for this state file.
+
+## C++/Python API
+
+[TopologicalCompression](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompression.html)
+
+[TopologicalCompressionReader](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompressionWriter.html)
+
+[TopologicalCompressionWriter](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompressionWriter.html)

--- a/docs/persistenceDrivenCompression.md
+++ b/docs/persistenceDrivenCompression.md
@@ -32,7 +32,15 @@ $ paraview states/persistenceDrivenCompression.pvsm
 
 ## Python code
 
-This script only loads the compressed data-sets.
+This script loads the uncompressed
+[naturalImage_original.vti](https://github.com/topology-tool-kit/ttk-data/raw/dev/naturalImage_original.vti)
+input file, saves it as in the TTK Topological Compressed Image Data
+file format, using
+[TopologicalCompressionWriter](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompressionWriter.html)
+under the hood. The produced file is then loaded with
+[TopologicalCompressionReader](https://topology-tool-kit.github.io/doc/html/classttkTopologicalCompressionWriter.html)
+and saved back to VTI. This demonstrates the use of the
+`TopologicalCompression` I/O modules.
 
 ``` python  linenums="1"
 --8<-- "python/persistenceDrivenCompression.py"
@@ -60,9 +68,8 @@ This script only loads the compressed data-sets.
 
 ## Outputs
 
-* `uncompressed_naturalImage_zfp50.vti`: the second input saved as a VTI file.
-* `uncompressed_naturalImage_persistence10.vti`: the third input saved as a VTI file.
-* `uncompressed_naturalImage_persistence10_zfp50.vti`: the last input saved as a VTI file.
+* `uncompressed_naturalImage_persistence10_zfp50.vti`: the first
+  input, compressed and saved as a VTI file.
 
 ## C++/Python API
 

--- a/python/persistenceDrivenCompression.py
+++ b/python/persistenceDrivenCompression.py
@@ -2,30 +2,25 @@
 
 from paraview.simple import *
 
-# create a new 'TTK TopologicalCompressionReader'
-naturalImage_zfp50ttk = TTKTopologicalCompressionReader(
-    FileName="naturalImage_zfp50.ttk"
+# read input VTI with 'XML Image Data Reader'
+naturalImage = XMLImageDataReader(FileName=["naturalImage_original.vti"])
+
+# compress & save to TTK Topological Compression format
+SaveData(
+    "naturalImage_persistence10_zfp50.ttk",
+    proxy=naturalImage,
+    ScalarField=["POINTS", "PNGImage"],
+    Topologicallosspersistencepercentage=10,  # Topological loss
+    ZFPRelativeErrorToleranceextra=50,  # ZFP Relative Error Tolerance
 )
 
-# create a new 'XML Image Data Reader'
-naturalImage_originalvti = XMLImageDataReader(FileName=["naturalImage_original.vti"])
-naturalImage_originalvti.PointArrayStatus = ["PNGImage"]
-naturalImage_originalvti.TimeArray = "None"
-
-# create a new 'TTK TopologicalCompressionReader'
-naturalImage_persistence10ttk = TTKTopologicalCompressionReader(
-    FileName="naturalImage_persistence10.ttk",
-)
-
-# create a new 'TTK TopologicalCompressionReader'
-naturalImage_persistence10_zfp50ttk = TTKTopologicalCompressionReader(
+# read the compressed file with 'TTK TopologicalCompressionReader'
+naturalImage_compressed = TTKTopologicalCompressionReader(
     FileName="naturalImage_persistence10_zfp50.ttk",
 )
 
-# save outputs to VTI
-SaveData("uncompressed_naturalImage_zfp50.vti", naturalImage_zfp50ttk)
-SaveData("uncompressed_naturalImage_persistence10.vti", naturalImage_persistence10ttk)
+# write compressed data-set to VTI
 SaveData(
     "uncompressed_naturalImage_persistence10_zfp50.vti",
-    naturalImage_persistence10_zfp50ttk,
+    naturalImage_compressed,
 )

--- a/python/persistenceDrivenCompression.py
+++ b/python/persistenceDrivenCompression.py
@@ -21,3 +21,11 @@ naturalImage_persistence10ttk = TTKTopologicalCompressionReader(
 naturalImage_persistence10_zfp50ttk = TTKTopologicalCompressionReader(
     FileName="naturalImage_persistence10_zfp50.ttk",
 )
+
+# save outputs to VTI
+SaveData("uncompressed_naturalImage_zfp50.vti", naturalImage_zfp50ttk)
+SaveData("uncompressed_naturalImage_persistence10.vti", naturalImage_persistence10ttk)
+SaveData(
+    "uncompressed_naturalImage_persistence10_zfp50.vti",
+    naturalImage_persistence10_zfp50ttk,
+)

--- a/python/persistenceDrivenCompression.py
+++ b/python/persistenceDrivenCompression.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from paraview.simple import *
+
+# create a new 'TTK TopologicalCompressionReader'
+naturalImage_zfp50ttk = TTKTopologicalCompressionReader(
+    FileName="naturalImage_zfp50.ttk"
+)
+
+# create a new 'XML Image Data Reader'
+naturalImage_originalvti = XMLImageDataReader(FileName=["naturalImage_original.vti"])
+naturalImage_originalvti.PointArrayStatus = ["PNGImage"]
+naturalImage_originalvti.TimeArray = "None"
+
+# create a new 'TTK TopologicalCompressionReader'
+naturalImage_persistence10ttk = TTKTopologicalCompressionReader(
+    FileName="naturalImage_persistence10.ttk",
+)
+
+# create a new 'TTK TopologicalCompressionReader'
+naturalImage_persistence10_zfp50ttk = TTKTopologicalCompressionReader(
+    FileName="naturalImage_persistence10_zfp50.ttk",
+)


### PR DESCRIPTION
This PR adds a simple Python script and a mkdocs file to document the ttk-data persistenceDataCompression state file.

The Python script doesn't do anything though, since the state file only loads data and does not process them.

Enjoy,
Pierre