### PR TITLE
Improve instructions for setting up local mkdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Linux file browser info
 .directory
+# virtual environment
+venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,9 +83,22 @@ Please find below generic recommendations for setting up your fork of TTK's data
     - Each input should contain a link to the actual file on [ttk-data](https://github.com/topology-tool-kit/ttk-data)
   - A quick description of the pipeline outputs
   - Pointers to the Doxygen documentation of all the TTK filters involved in the example.
-- Note that the output webpage can be visualized locally by entering the command `mkdocs serve` in the [ttk-data](https://github.com/topology-tool-kit/ttk-data) directory.
 - Once your example is merged to [ttk-data](https://github.com/topology-tool-kit/ttk-data), please open a pull request to the main [ttk](https://github.com/topology-tool-kit/ttk) repository, to insert pointers to your example in the doxygen documentation and ParaView documentation of all the TTK filters involved in your example. See for instance the section "Online examples" in:
   - https://github.com/topology-tool-kit/ttk/blob/dev/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
   - https://github.com/topology-tool-kit/ttk/blob/dev/paraview/xmls/PersistenceDiagram.xml
 
 - In the three cases above (`pvsm` ParaView state file, `py` Python script, `.md` MkDocs entry), we invite you to checkout the other examples already included in [ttk-data](https://github.com/topology-tool-kit/ttk-data) for inspiration.
+
+### Running mkdocs locally
+
+Set up and activate a virtual environment:
+```bash
+virtualenv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run local server, which updates automatically on change; by default it runs on http://localhost:8000/
+```bash
+mkdocs serve
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,14 @@ Please find below generic recommendations for setting up your fork of TTK's data
     - Each input should contain a link to the actual file on [ttk-data](https://github.com/topology-tool-kit/ttk-data)
   - A quick description of the pipeline outputs
   - Pointers to the Doxygen documentation of all the TTK filters involved in the example.
+- Note that the output webpage can be visualized locally by entering the command `mkdocs serve` in the [ttk-data](https://github.com/topology-tool-kit/ttk-data) directory (installation instructions for pip users are included below, otherwise please refer to your system's package manager).
 - Once your example is merged to [ttk-data](https://github.com/topology-tool-kit/ttk-data), please open a pull request to the main [ttk](https://github.com/topology-tool-kit/ttk) repository, to insert pointers to your example in the doxygen documentation and ParaView documentation of all the TTK filters involved in your example. See for instance the section "Online examples" in:
   - https://github.com/topology-tool-kit/ttk/blob/dev/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
   - https://github.com/topology-tool-kit/ttk/blob/dev/paraview/xmls/PersistenceDiagram.xml
 
 - In the three cases above (`pvsm` ParaView state file, `py` Python script, `.md` MkDocs entry), we invite you to checkout the other examples already included in [ttk-data](https://github.com/topology-tool-kit/ttk-data) for inspiration.
 
-### Running mkdocs locally
+### Running mkdocs locally (pip users)
 
 Set up and activate a virtual environment:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs
+mkdocs-material
+pymdown-extensions


### PR DESCRIPTION
This PR adds a `requirements.txt`, which contains a list of Python packages required for mkdocs, as well as instructions for how to set up a virtualenv.

This should make it easier for future contributors to run mkdocs locally.