### PR TITLE
Document Python scripts CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,15 @@ Please find below generic recommendations for setting up your fork of TTK's data
     - Remove the construction of graphical primitives (`tTKIcospheresFromPoints`, `Tube`, `GenerateSurfaceNormals`) which are not needed in batch mode. In batch mode, the raw data (input of these graphical primitives) is usually more convenient to handle.
     - The simplified script should be **straightforward to understand**
   - Run your python script and **double check** if its output is correct in ParaView!
+  - Format your Python script using
+    [Black](https://github.com/psf/black). You can also integrate it
+    into your local Git repository using [pre-commit
+    hooks](https://black.readthedocs.io/en/stable/integrations/source_version_control.html)
+    to ensure that only well-formatted Python code is commited.
+  - Run if possible the TTK CI to get the script output hashes and add
+    them to the corresponding platform file in the `python/hashes`
+    directory (more information in the relevant
+    [README](./python/README.md) file in the `python` directory).
 
 ## c. MkDocs file
 - This file should be located in the `docs/` directory and have the same name as the state file and the Python script, but with the `md` extension (instead of `pvsm` or `py`).

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,16 @@
+This directory contains one particular Python script,
+[run.py](./run.py), whose job is to run all other scripts located in
+the same directory. These scripts will generate VTK datasets or CSV
+outputs, stored in the `output_datasets` sub-directory. For each of
+these outputs, a [SHA-1](https://en.wikipedia.org/wiki/SHA-1) digest
+is computed and stored in alphabetical order in JSON format in a file
+named `res.json` that resides in the current folder.
+
+This `res.json` file can be renamed and compared to a future run of
+the `run.py` script to check if the script outputs have changed. This
+is the role of the platform files in the `python/hashes`
+directory. These files store the hashes for the TTK GitHub Actions CI
+(Ubuntu, macOS, Windows); the CI should print their content at the end
+of the `Run ttk-data Python scripts` job log of the `test_build`
+workflow. This allow for the hashes to be updated by overwriting the
+files with the CI results.

--- a/tests/run.py
+++ b/tests/run.py
@@ -54,6 +54,8 @@ def run_all(dest):
     p = pathlib.Path(os.path.realpath(__file__)).parents[1]
     os.chdir(p)
 
+    fails = []
+
     # create destination directory
     try:
         os.mkdir(dest)
@@ -70,6 +72,10 @@ def run_all(dest):
             )
             proc.start()
             proc.join()
+            if proc.exitcode != 0:
+                fails.append(state.name)
+
+    print(f"Failing cases: {fails}")
 
 
 def main():


### PR DESCRIPTION
This PR improves the documentation around the Python scripts:
* it mentions the  [Black](https://github.com/psf/black) formatter for Python code in CONTRIBUTING.md and the CI-generated hashes,
* a README inside the `python` directory explains the role of the `python/run.py` script in the CI,
* the PVSM CI now displays a list of failing test cases (usually due to missing RAM in GitHub Actions VMs).

Enjoy,
Pierre