### PR TITLE
python/hashes: Add missing ctBones Windows hash

### DIFF
--- a/python/hashes/windows.json
+++ b/python/hashes/windows.json
@@ -48,6 +48,7 @@
     "contourTreeAlignment_Segmentations_7_0": "d74dacaf077737950f53b7e171c2c1692919ea76",
     "contourTreeAlignment_Segmentations_8_0": "74dbce6d5a6a5b218674d48fe176b534c7e7e43b",
     "contourTreeAlignment_Segmentations_9_0": "b20108812f8a28f8dabaaac5a3cc82fccbb40ff6",
+    "ctBones_CTBonesOutputSegmentation": "cd780bfd6755911bb151a0d90ddb11a890168cbc",
     "data": "f52c4e70be594e7c32b8bd53c903aa701baa662b",
     "dragon_ContourTreeArcs": "92d3b15f3053965c72cd2a711bddffab579e93d6",
     "dragon_ContourTreeNodes": "1cabfc187d80b0fd86a7ef2fc7cc8c70ed173248",


### PR DESCRIPTION
Following https://github.com/topology-tool-kit/ttk/pull/750, the `ctBones` Python script now works on Windows (the state was previously failing due to missing memory capacity). This PR adds the missing hash to make the CI happy.

Enjoy,
Pierre