### PR TITLE
Force FTM backend for PersistenceDiagrams

### DIFF
--- a/python/1manifoldLearning.py
+++ b/python/1manifoldLearning.py
@@ -53,6 +53,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/1manifoldLearningCircles.py
+++ b/python/1manifoldLearningCircles.py
@@ -42,6 +42,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/2manifoldLearning.py
+++ b/python/2manifoldLearning.py
@@ -33,6 +33,7 @@ gaussianResampling1.ResamplingGrid = [64, 64, 128]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=gaussianResampling1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/builtInExample1.py
+++ b/python/builtInExample1.py
@@ -50,6 +50,7 @@ tetrahedralize1 = Tetrahedralize(Input=tTKScalarFieldNormalizer1)
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=tetrahedralize1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "myVorticity"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 persistencePairs = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/ctBones.py
+++ b/python/ctBones.py
@@ -22,6 +22,7 @@ ctBonesvti = XMLImageDataReader(FileName=["ctBones.vti"])
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=ctBonesvti)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "Scalars_"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/dragon.py
+++ b/python/dragon.py
@@ -34,6 +34,7 @@ tTKPersistenceCurve1.ScalarField = ["POINTS", "Elevation"]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=elevation)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "Elevation"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 pairs = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/harmonicSkeleton.py
+++ b/python/harmonicSkeleton.py
@@ -117,6 +117,7 @@ tTKScalarFieldNormalizer1.ScalarField = ["POINTS", "ScaledHarmonic"]
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=tTKScalarFieldNormalizer1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "ScaledHarmonic"]
 tTKPersistenceDiagram1.EmbedinDomain = 1
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/imageProcessing.py
+++ b/python/imageProcessing.py
@@ -33,6 +33,7 @@ calculator1.Function = "mag(ScalarGradient)"
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=calculator1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "gradient"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/interactionSites.py
+++ b/python/interactionSites.py
@@ -37,6 +37,7 @@ tTKPersistenceCurve1.ScalarField = ["POINTS", "log(s)"]
 # compute the 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=builtInExamplevti)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "log(s)"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/karhunenLoveDigits64Dimensions.py
+++ b/python/karhunenLoveDigits64Dimensions.py
@@ -115,6 +115,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/morsePersistence.py
+++ b/python/morsePersistence.py
@@ -65,6 +65,7 @@ tTKPersistenceCurve1.ScalarField = ["POINTS", "Blend"]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=warpByScalar1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "Blend"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/morseSmaleQuadrangulation.py
+++ b/python/morseSmaleQuadrangulation.py
@@ -32,6 +32,7 @@ tTKScalarFieldNormalizer1.ScalarField = ["POINTS", "Result"]
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=tTKScalarFieldNormalizer1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "Result"]
 tTKPersistenceDiagram1.EmbedinDomain = 1
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/persistenceClustering0.py
+++ b/python/persistenceClustering0.py
@@ -42,6 +42,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/persistenceClustering1.py
+++ b/python/persistenceClustering1.py
@@ -40,6 +40,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/persistenceClustering2.py
+++ b/python/persistenceClustering2.py
@@ -41,6 +41,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/persistenceClustering3.py
+++ b/python/persistenceClustering3.py
@@ -40,6 +40,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/persistenceClustering4.py
+++ b/python/persistenceClustering4.py
@@ -40,6 +40,7 @@ slice1.SliceType.Normal = [0.0, 0.0, 1.0]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=slice1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/tectonicPuzzle.py
+++ b/python/tectonicPuzzle.py
@@ -44,6 +44,7 @@ calculator1.Function = "log10(Viscosity)"
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=calculator1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "logViscosity"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold2 = Threshold(Input=tTKPersistenceDiagram1)
@@ -101,6 +102,7 @@ tTKTopologicalSimplification2.ScalarField = ["POINTS", "logViscosity"]
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram2 = TTKPersistenceDiagram(Input=tTKTopologicalSimplification2)
 tTKPersistenceDiagram2.ScalarField = ["POINTS", "logViscosity"]
+tTKPersistenceDiagram2.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold4 = Threshold(Input=tTKPersistenceDiagram2)

--- a/python/tribute.py
+++ b/python/tribute.py
@@ -26,6 +26,7 @@ calculator1.Function = "sqrt(PNGImage_X*PNGImage_X+PNGImage_Y*PNGImage_Y)"
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=calculator1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "originalData"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)

--- a/python/uncertainStartingVortex.py
+++ b/python/uncertainStartingVortex.py
@@ -55,6 +55,7 @@ calculator1.Function = (
 # create a new 'TTK PersistenceDiagram'
 tTKPersistenceDiagram1 = TTKPersistenceDiagram(Input=calculator1)
 tTKPersistenceDiagram1.ScalarField = ["POINTS", "realization0"]
+tTKPersistenceDiagram1.Backend = "FTM (IEEE TPSD 2019)"
 
 # create a new 'Threshold'
 threshold2 = Threshold(Input=tTKPersistenceDiagram1)

--- a/states/1manifoldLearningCircles.pvsm
+++ b/states/1manifoldLearningCircles.pvsm
@@ -59405,6 +59405,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="14964" servers="1">
+      <Property name="BackEnd" id="14964.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="14964.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="14964.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="14964.Debug_DebugLevel.range"/>

--- a/states/BuiltInExample1.pvsm
+++ b/states/BuiltInExample1.pvsm
@@ -28809,6 +28809,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15624" servers="1">
+      <Property name="BackEnd" id="15624.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15624.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="15624.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="15624.Debug_DebugLevel.range"/>

--- a/states/BuiltInExample3.pvsm
+++ b/states/BuiltInExample3.pvsm
@@ -60907,6 +60907,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="14844" servers="1">
+      <Property name="BackEnd" id="14844.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="14844.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="14844.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="14844.Debug_DebugLevel.range"/>
@@ -60962,6 +60972,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="16044" servers="1">
+      <Property name="BackEnd" id="16044.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="16044.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="16044.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="16044.Debug_DebugLevel.range"/>

--- a/states/contourAroundPoint.pvsm
+++ b/states/contourAroundPoint.pvsm
@@ -40767,6 +40767,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15991" servers="1">
+      <Property name="BackEnd" id="15991.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15991.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="15991.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="15991.Debug_DebugLevel.range"/>
@@ -40820,6 +40830,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="14020" servers="1">
+      <Property name="BackEnd" id="14020.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="14020.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="14020.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="14020.Debug_DebugLevel.range"/>

--- a/states/ctBones.pvsm
+++ b/states/ctBones.pvsm
@@ -45726,6 +45726,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="14711" servers="1">
+      <Property name="BackEnd" id="14711.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="14711.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="14711.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="14711.Debug_DebugLevel.range"/>

--- a/states/dragon.pvsm
+++ b/states/dragon.pvsm
@@ -38322,6 +38322,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15563" servers="1">
+      <Property name="BackEnd" id="15563.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15563.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="15563.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="15563.Debug_DebugLevel.range"/>

--- a/states/harmonicSkeleton.pvsm
+++ b/states/harmonicSkeleton.pvsm
@@ -40466,6 +40466,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="17048" servers="1">
+      <Property name="BackEnd" id="17048.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="17048.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="17048.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="17048.Debug_DebugLevel.range"/>

--- a/states/imageProcessing.pvsm
+++ b/states/imageProcessing.pvsm
@@ -48347,6 +48347,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15584" servers="1">
+      <Property name="BackEnd" id="15584.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15584.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="DMT Pairs" id="15584.DMT Pairs" number_of_elements="1">
         <Element index="0" value="0"/>
         <Domain name="bool" id="15584.DMT Pairs.bool"/>

--- a/states/karhunenLoveDigits64Dimensions.pvsm
+++ b/states/karhunenLoveDigits64Dimensions.pvsm
@@ -49498,6 +49498,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="9310" servers="1">
+      <Property name="BackEnd" id="9310.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="9310.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="DebugLevel" id="9310.DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="9310.DebugLevel.range"/>

--- a/states/morsePersistence.pvsm
+++ b/states/morsePersistence.pvsm
@@ -23910,6 +23910,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="16702" servers="1">
+      <Property name="BackEnd" id="16702.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="16702.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="16702.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="16702.Debug_DebugLevel.range"/>

--- a/states/persistenceClustering0.pvsm
+++ b/states/persistenceClustering0.pvsm
@@ -39697,6 +39697,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="14954" servers="1">
+      <Property name="BackEnd" id="14954.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="14954.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="14954.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="14954.Debug_DebugLevel.range"/>

--- a/states/persistenceClustering1.pvsm
+++ b/states/persistenceClustering1.pvsm
@@ -39697,6 +39697,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="9489" servers="1">
+      <Property name="BackEnd" id="9489.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="9489.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="9489.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="9489.Debug_DebugLevel.range"/>

--- a/states/persistenceClustering2.pvsm
+++ b/states/persistenceClustering2.pvsm
@@ -39701,6 +39701,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="9489" servers="1">
+      <Property name="BackEnd" id="9489.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="9489.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="9489.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="9489.Debug_DebugLevel.range"/>

--- a/states/persistenceClustering3.pvsm
+++ b/states/persistenceClustering3.pvsm
@@ -39697,6 +39697,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="9489" servers="1">
+      <Property name="BackEnd" id="9489.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="9489.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="9489.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="9489.Debug_DebugLevel.range"/>

--- a/states/timeTracking.pvsm
+++ b/states/timeTracking.pvsm
@@ -57560,6 +57560,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15392" servers="1">
+      <Property name="BackEnd" id="15392.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15392.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="DebugLevel" id="15392.DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="15392.DebugLevel.range"/>
@@ -57612,6 +57622,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="19203" servers="1">
+      <Property name="BackEnd" id="19203.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="19203.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="DebugLevel" id="19203.DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="19203.DebugLevel.range"/>

--- a/states/tribute.pvsm
+++ b/states/tribute.pvsm
@@ -70505,6 +70505,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15727" servers="1">
+      <Property name="BackEnd" id="15727.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15727.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="15727.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="15727.Debug_DebugLevel.range"/>

--- a/states/uncertainStartingVortex.pvsm
+++ b/states/uncertainStartingVortex.pvsm
@@ -45807,6 +45807,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="15418" servers="1">
+      <Property name="BackEnd" id="15418.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="15418.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="15418.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="15418.Debug_DebugLevel.range"/>
@@ -45866,6 +45876,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="19585" servers="1">
+      <Property name="BackEnd" id="19585.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="19585.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="19585.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="19585.Debug_DebugLevel.range"/>

--- a/states/viscousFingering.pvsm
+++ b/states/viscousFingering.pvsm
@@ -64668,6 +64668,16 @@
       </Property>
     </Proxy>
     <Proxy group="filters" type="ttkPersistenceDiagram" id="16087" servers="1">
+      <Property name="BackEnd" id="16087.BackEnd" number_of_elements="1">
+        <Element index="0" value="0"/>
+        <Domain name="enum" id="16087.BackEnd.enum">
+          <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
+          <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
+        </Domain>
+      </Property>
       <Property name="Debug_DebugLevel" id="16087.Debug_DebugLevel" number_of_elements="1">
         <Element index="0" value="3"/>
         <Domain name="range" id="16087.Debug_DebugLevel.range"/>


### PR DESCRIPTION
This PR force the PersistenceDiagram filter to use the FTM backend for all relevant ParaView state files and Python scripts.

Enjoy,
Pierre