### PR TITLE
Update Merge Tree python scripts and docs with the new input format

### DIFF
--- a/docs/mergeTreeClustering.md
+++ b/docs/mergeTreeClustering.md
@@ -3,7 +3,7 @@
 ![Merge Tree Clustering example Image](https://topology-tool-kit.github.io/img/gallery/mergeTreeClustering.jpg)
 
 ## Pipeline description
-This example first loads an ensemble of scalar fields inside a single file from disk.
+This example first loads an ensemble of scalar fields inside a cinema database from disk.
 Then, the [FTMTree](https://topology-tool-kit.github.io/doc/html/classttkFTMTree.html) is computed on each scalar field for the Join Tree and the Split Tree.
 
 All these trees are passed to [MergeTreeClustering](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeClustering.html) to compute a clustering in the metric space of merge trees. Each input is considered as a tuple consisting of the Join Tree and the Split Tree of the corresponding scalar field. Each centroid is also a tuple of this kind and a distance between two tuples is the distance between their Join Tree plus the distance between their Split Trees.
@@ -31,7 +31,7 @@ $ paraview --state=states/mergeTreeClustering.pvsm
 ```
 
 ## Inputs
-- [isabel.vti](https://github.com/topology-tool-kit/ttk-data/raw/dev/isabel.vti): a three-dimensional regular grid with 12 scalar fields.
+- [Isabel.cdb](https://github.com/topology-tool-kit/ttk-data/tree/dev/Isabel.cdb): a cinema database containing 12 regular grids.
 
 ## Outputs
 -  `MDS_trees.vtu`: the output points in 2D MDS (MultiDimensional Scaling) corresponding to the input trees. The 'ClusterAssignment' array contains the clustering assignments.

--- a/docs/mergeTreeTemporalReduction.md
+++ b/docs/mergeTreeTemporalReduction.md
@@ -3,7 +3,7 @@
 ![Merge Tree Temporal Reduction example Image](https://topology-tool-kit.github.io/img/gallery/mergeTreeTemporalReduction.jpg)
 
 ## Pipeline description
-This example first loads an ensemble of scalar fields inside a single file from disk.
+This example first loads an ensemble of scalar fields inside a cinema database from disk.
 Then, the [Split Tree](https://topology-tool-kit.github.io/doc/html/classttkFTMTree.html) is computed on each scalar field.
 
 All these trees are passed to [MergeTreeTemporalReductionEncoding](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeTemporalReductionEncoding.html) to compute a subsampling of a sequence of merge trees. The algorithm greedily removes trees in the sequence that can be accurately reconstructed by the geodesic computation. The remaining trees are called the key frames.
@@ -25,7 +25,7 @@ $ paraview --state=states/mergeTreeTemporalReduction.pvsm
 ```
 
 ## Inputs
-- [isabel.vti](https://github.com/topology-tool-kit/ttk-data/raw/dev/isabel.vti): a three-dimensional regular grid with 12 scalar fields.
+- [Isabel.cdb](https://github.com/topology-tool-kit/ttk-data/tree/dev/Isabel.cdb): a cinema database containing 12 regular grids.
 
 ## Outputs
 -  `ReductionCoefficients.csv`: a table containing information needed to reconstruct removed trees. For each removed tree we have the id of the two key frames needed to reconstruct it ('Index1' and 'Index2'), along with the interpolation parameter ('Alpha').

--- a/python/mergeTreeTemporalReduction.py
+++ b/python/mergeTreeTemporalReduction.py
@@ -2,44 +2,21 @@
 
 from paraview.simple import *
 
-# create a new 'XML Image Data Reader'
-isabelvti = XMLImageDataReader(FileName=["isabel.vti"])
+# create a new 'TTK CinemaReader'
+tTKCinemaReader1 = TTKCinemaReader(DatabasePath='./Isabel.cdb')
 
-all_MT_group = []
+# create a new 'TTK CinemaProductReader'
+tTKCinemaProductReader1 = TTKCinemaProductReader(Input=tTKCinemaReader1)
+tTKCinemaProductReader1.AddFieldDataRecursively = 1
 
-scalarFields = [
-    "velocityMag_02",
-    "velocityMag_03",
-    "velocityMag_04",
-    "velocityMag_05",
-    "velocityMag_30",
-    "velocityMag_31",
-    "velocityMag_32",
-    "velocityMag_33",
-    "velocityMag_45",
-    "velocityMag_46",
-    "velocityMag_47",
-    "velocityMag_48",
-]
-for scalarField in scalarFields:
-    # create a new 'TTK Merge and Contour Tree (FTM)'
-    tTKMergeandContourTreeFTM1 = TTKMergeandContourTreeFTM(Input=isabelvti)
-    tTKMergeandContourTreeFTM1.ScalarField = ["POINTS", scalarField]
-    tTKMergeandContourTreeFTM1.TreeType = "Split Tree"
-
-    # create a new 'Group Datasets'
-    groupDatasets1 = GroupDatasets(
-        Input=[
-            tTKMergeandContourTreeFTM1,
-            OutputPort(tTKMergeandContourTreeFTM1, 1),
-            OutputPort(tTKMergeandContourTreeFTM1, 2),
-        ]
-    )
-
-    all_MT_group.append(groupDatasets1)
+# create a new 'TTK Merge and Contour Tree (FTM)'
+tTKMergeandContourTreeFTM26 = TTKMergeandContourTreeFTM(Input=tTKCinemaProductReader1)
+tTKMergeandContourTreeFTM26.ScalarField = ['POINTS', 'velocityMag']
+tTKMergeandContourTreeFTM26.InputOffsetField = ['POINTS', 'velocityMag']
+tTKMergeandContourTreeFTM26.TreeType = 'Split Tree'
 
 # create a new 'Group Datasets'
-all_MT = GroupDatasets(Input=all_MT_group)
+all_MT = GroupDatasets(Input=[tTKMergeandContourTreeFTM26, OutputPort(tTKMergeandContourTreeFTM26,1), OutputPort(tTKMergeandContourTreeFTM26,2)])
 
 # create a new 'TTK MergeTreeTemporalReductionEncoding'
 tTKMergeTreeTemporalReductionEncoding1 = TTKMergeTreeTemporalReductionEncoding(


### PR DESCRIPTION
This PR modifies the mergeTree python scripts and doc files to take into account the new input format of the mergeTree filters of TTK (topology-tool-kit/ttk#784) and also to use the isabel cinema database instead of isabel.vti.