### PR TITLE
Python: Remove Threshold compatibility

### DIFF
--- a/python/1manifoldLearning.py
+++ b/python/1manifoldLearning.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 pointCloudcsv = CSVReader(FileName=["pointCloud.csv"])
 
@@ -57,12 +43,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=threshold1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 3.0, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 3.0
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(
@@ -77,7 +67,9 @@ tTKMorseSmaleComplex1.ScalarField = ["POINTS", "SplatterValues"]
 # create a new 'Threshold'
 threshold2 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 1))
 threshold2.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold2, 1.0, 1.0)
+threshold2.ThresholdMethod = "Between"
+threshold2.LowerThreshold = 1.0
+threshold2.UpperThreshold = 1.0
 
 # create a new 'Threshold'
 threshold3 = Threshold(Input=threshold2)

--- a/python/1manifoldLearningCircles.py
+++ b/python/1manifoldLearningCircles.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 clustering0csv = CSVReader(FileName=["clustering0.csv"])
 
@@ -47,12 +33,16 @@ tTKPersistenceDiagram1.IgnoreBoundary = True
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=threshold1)
 persistenceThreshold0.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold0, 10.0, 999999999)
+persistenceThreshold0.ThresholdMethod = "Between"
+persistenceThreshold0.LowerThreshold = 10.0
+persistenceThreshold0.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(
@@ -67,12 +57,16 @@ tTKMorseSmaleComplex1.ScalarField = ["POINTS", "SplatterValues"]
 # create a new 'Threshold'
 threshold2 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 1))
 threshold2.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold2, 1.0, 1.0)
+threshold2.ThresholdMethod = "Between"
+threshold2.LowerThreshold = 1.0
+threshold2.UpperThreshold = 1.0
 
 # create a new 'Threshold'
 threshold3 = Threshold(Input=threshold2)
 threshold3.Scalars = ["CELLS", "SeparatrixFunctionMinimum"]
-ThresholdBetween(threshold3, 2.0, 999999999)
+threshold3.ThresholdMethod = "Between"
+threshold3.LowerThreshold = 2.0
+threshold3.UpperThreshold = 999999999
 
 # create a new 'Resample With Dataset'
 resampleWithDataset1 = ResampleWithDataset(

--- a/python/2manifoldLearning.py
+++ b/python/2manifoldLearning.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 pointCloudcsv = CSVReader(FileName=["pointCloud.csv"])
 
@@ -37,12 +23,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=threshold1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 0.01, 999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 0.01
+persistenceThreshold.UpperThreshold = 999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/BuiltInExample1.py
+++ b/python/BuiltInExample1.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Image Data Reader'
 builtInExamplevti = XMLImageDataReader(FileName=["BuiltInExample1.vti"])
 
@@ -55,12 +41,16 @@ tTKPersistenceDiagram1.IgnoreBoundary = True
 # create a new 'Threshold'
 persistencePairs = Threshold(Input=tTKPersistenceDiagram1)
 persistencePairs.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(persistencePairs, -0.1, 999999999)
+persistencePairs.ThresholdMethod = "Between"
+persistencePairs.LowerThreshold = -0.1
+persistencePairs.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=persistencePairs)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 0.02, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 0.02
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK PersistenceCurve'
 tTKPersistenceCurve1 = TTKPersistenceCurve(Input=tTKPersistenceDiagram1)

--- a/python/builtInExample2.py
+++ b/python/builtInExample2.py
@@ -1,20 +1,6 @@
 #### import the simple module from the paraview
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # Load the scalar fields using 'XML Image Data Reader'
 example2vti = XMLImageDataReader(FileName=["BuiltInExample2.vti"])
 
@@ -41,7 +27,9 @@ tTKContinuousScatterPlot1.UseAllCores = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKContinuousScatterPlot1)
 threshold1.Scalars = ["POINTS", "ValidPointMask"]
-ThresholdBetween(threshold1, 0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'TTK ProjectionFromField' to project the 'log(Rho)' contour onto the range space
 tTKProjectionFromField1 = TTKProjectionFromField(Input=contour2)

--- a/python/ctBones.py
+++ b/python/ctBones.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Image Data Reader'
 ctBonesvti = XMLImageDataReader(FileName=["ctBones.vti"])
 
@@ -33,12 +19,16 @@ tTKPersistenceDiagram1.Saddlesaddlediagramdimension1slowest = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, 0, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.0
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=threshold1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 180.0, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 180.0
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(
@@ -56,6 +46,8 @@ tTKMergeandContourTreeFTM1.TreeType = "Join Tree"
 # create a new 'Threshold'
 threshold3 = Threshold(Input=OutputPort(tTKMergeandContourTreeFTM1, 2))
 threshold3.Scalars = ["POINTS", "RegionType"]
-ThresholdBetween(threshold3, 0.0, 0.0)
+threshold3.ThresholdMethod = "Between"
+threshold3.LowerThreshold = 0.0
+threshold3.UpperThreshold = 0.0
 
 SaveData("CTBonesOutputSegmentation.vtu", threshold3)

--- a/python/dragon.py
+++ b/python/dragon.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Unstructured Grid Reader'
 dragonvtu = XMLUnstructuredGridReader(FileName=["dragon.vtu"])
 
@@ -38,12 +24,16 @@ tTKPersistenceCurve1 = TTKPersistenceCurve(Input=tTKPersistenceDiagram1)
 # create a new 'Threshold'
 pairs = Threshold(Input=tTKPersistenceDiagram1)
 pairs.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(pairs, 0.0, 999999999)
+pairs.ThresholdMethod = "Between"
+pairs.LowerThreshold = 0.0
+pairs.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=pairs)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 5.0, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 5.0
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/geometryApproximation.py
+++ b/python/geometryApproximation.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML PolyData Reader'
 stonevtp = XMLPolyDataReader(FileName=["GroundWater.cdb/stone.vtp"])
 
@@ -41,7 +27,9 @@ tTKDepthImageBasedGeometryApproximation1.DepthArray = ["POINTS", "Depth"]
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKDepthImageBasedGeometryApproximation1)
 threshold1.Scalars = ["CELLS", "TriangleDistortion"]
-ThresholdBetween(threshold1, -999999999, 0.02)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -999999999
+threshold1.UpperThreshold = 0.02
 
 SaveData("CinemaImages.vtm", tTKCinemaImaging1)
 SaveData("GeometryApproximatedStone.vtm", threshold1)

--- a/python/harmonicSkeleton.py
+++ b/python/harmonicSkeleton.py
@@ -3,20 +3,6 @@
 #### import the simple module from the paraview
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # load the pegasus dataset by creating a'XML Unstructured Grid Reader'
 pegasusvtu = XMLUnstructuredGridReader(FileName=["pegasus.vtu"])
 
@@ -121,7 +107,9 @@ tTKPersistenceDiagram1.EmbedinDomain = 1
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(threshold1, 0.001, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.001
+threshold1.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/imageProcessing.py
+++ b/python/imageProcessing.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 naturalImagepng = PNGSeriesReader(FileNames=["naturalImage.png"])
 
 # create a new 'Compute Derivatives'
@@ -37,12 +23,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "gradient"]
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, 0, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.0
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=threshold1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 6.0, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 6.0
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(
@@ -58,7 +48,9 @@ tTKMorseSmaleComplex1.ScalarField = ["POINTS", "gradient"]
 # create a new 'Threshold'
 threshold3 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 1))
 threshold3.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold3, 1.0, 1.0)
+threshold3.ThresholdMethod = "Between"
+threshold3.LowerThreshold = 1.0
+threshold3.UpperThreshold = 1.0
 
 # create a new 'TTK IdentifierRandomizer'
 tTKIdentifierRandomizer1 = TTKIdentifierRandomizer(

--- a/python/interactionSites.py
+++ b/python/interactionSites.py
@@ -1,20 +1,6 @@
 #### import the simple module from the paraview
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Image Data Reader'
 builtInExamplevti = XMLImageDataReader(FileName=["BuiltInExample2.vti"])
 
@@ -40,12 +26,16 @@ tTKPersistenceCurve1 = TTKPersistenceCurve(Input=tTKPersistenceDiagram1)
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, 0, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.0
+threshold1.UpperThreshold = 999999999
 
 # remove low persistence critical points using 'Threshold'
 persistenceThreshold = Threshold(Input=threshold1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 0.5, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 0.5
+persistenceThreshold.UpperThreshold = 999999999
 
 # simplify the field using 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(
@@ -82,7 +72,9 @@ threshold6.Scalars = ["POINTS", "RegionType"]
 # create a new 'Threshold'
 threshold7 = Threshold(Input=threshold6)
 threshold7.Scalars = ["POINTS", "SegmentationId"]
-ThresholdBetween(threshold7, 13.0, 13.0)
+threshold7.ThresholdMethod = "Between"
+threshold7.LowerThreshold = 13.0
+threshold7.UpperThreshold = 13.0
 
 # create a new 'Extract Surface'
 extractSurface5 = ExtractSurface(Input=threshold7)

--- a/python/karhunenLoveDigits64Dimensions.py
+++ b/python/karhunenLoveDigits64Dimensions.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 karhunenLoveDigits64Dimensionscsv = CSVReader(
     FileName=["karhunenLoveDigits64Dimensions.csv"]
@@ -121,7 +107,9 @@ tTKPersistenceDiagram1.IgnoreBoundary = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(threshold1, 10.0, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 10.0
+threshold1.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/manifoldCheck0.py
+++ b/python/manifoldCheck0.py
@@ -1,20 +1,6 @@
 #!/usr/bin/env python
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Unstructured Grid Reader'
 manifoldCheck0vtu = XMLUnstructuredGridReader(FileName=["manifoldCheck0.vtu"])
 
@@ -35,7 +21,9 @@ maskPoints1.SingleVertexPerCell = 1
 # this extracts non-manifold vertices
 threshold1 = Threshold(Input=maskPoints1)
 threshold1.Scalars = ["POINTS", "VertexLinkComponentNumber"]
-ThresholdBetween(threshold1, 2.0, 2.0)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 2.0
+threshold1.UpperThreshold = 2.0
 
 # save the output
 SaveData("manifoldCheck0_check.vtu", tTKManifoldCheck1)

--- a/python/manifoldCheck1.py
+++ b/python/manifoldCheck1.py
@@ -1,20 +1,6 @@
 #!/usr/bin/env python
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Unstructured Grid Reader'
 manifoldCheck1vtu = XMLUnstructuredGridReader(FileName=["manifoldCheck1.vtu"])
 
@@ -31,7 +17,9 @@ extractEdges2 = ExtractEdges(Input=tTKManifoldCheck2)
 # this extracts non-manifold edges
 threshold2 = Threshold(Input=extractEdges2)
 threshold2.Scalars = ["POINTS", "EdgeLinkComponentNumber"]
-ThresholdBetween(threshold2, 2.0, 2.0)
+threshold2.ThresholdMethod = "Between"
+threshold2.LowerThreshold = 2.0
+threshold2.UpperThreshold = 2.0
 
 # save the output
 SaveData("manifoldCheck1_check.vtu", tTKManifoldCheck2)

--- a/python/manifoldCheck2.py
+++ b/python/manifoldCheck2.py
@@ -1,20 +1,6 @@
 #!/usr/bin/env python
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Unstructured Grid Reader'
 manifoldCheck2vtu = XMLUnstructuredGridReader(FileName=["manifoldCheck2.vtu"])
 
@@ -32,7 +18,9 @@ tTKManifoldCheck3 = TTKManifoldCheck(
 # this extracts tetrahedra that contain non-manifold faces
 threshold3 = Threshold(registrationName="Threshold3", Input=tTKManifoldCheck3)
 threshold3.Scalars = ["CELLS", "TriangleLinkComponentNumber"]
-ThresholdBetween(threshold3, 3.0, 3.0)
+threshold3.ThresholdMethod = "Between"
+threshold3.LowerThreshold = 3.0
+threshold3.UpperThreshold = 3.0
 
 # create a new 'Generate Ids'
 generateIds1 = GenerateIds(registrationName="GenerateIds1", Input=threshold3)
@@ -43,7 +31,9 @@ generateIds1.CellIdsArrayName = "CellIdentifiers"
 # select two of the tetrahedra
 threshold4 = Threshold(registrationName="Threshold4", Input=generateIds1)
 threshold4.Scalars = ["CELLS", "CellIdentifiers"]
-ThresholdBetween(threshold4, 0, 1.0)
+threshold4.ThresholdMethod = "Between"
+threshold4.LowerThreshold = 0.0
+threshold4.UpperThreshold = 1.0
 
 # create a new 'Extract Surface'
 extractSurface2 = ExtractSurface(registrationName="ExtractSurface2", Input=threshold4)
@@ -52,7 +42,9 @@ extractSurface2 = ExtractSurface(registrationName="ExtractSurface2", Input=thres
 # this extracts non-manifold faces
 threshold5 = Threshold(registrationName="Threshold5", Input=extractSurface2)
 threshold5.Scalars = ["POINTS", "TriangleLinkComponentNumber"]
-ThresholdBetween(threshold5, 3.0, 3.0)
+threshold5.ThresholdMethod = "Between"
+threshold5.LowerThreshold = 3.0
+threshold5.UpperThreshold = 3.0
 
 # save the output
 SaveData("manifoldCheck2_check.vtu", tTKManifoldCheck3)

--- a/python/mergeTreeClustering.py
+++ b/python/mergeTreeClustering.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'TTK CinemaReader'
 tTKCinemaReader1 = TTKCinemaReader(DatabasePath="./Isabel.cdb")
 
@@ -142,12 +128,16 @@ maskPoints1.SingleVertexPerCell = 1
 # create a new 'Threshold'
 threshold33 = Threshold(Input=maskPoints1)
 threshold33.Scalars = ["POINTS", "treeID"]
-ThresholdBetween(threshold33, 0.0, 11.0)
+threshold33.ThresholdMethod = "Between"
+threshold33.LowerThreshold = 0.0
+threshold33.UpperThreshold = 11.0
 
 # create a new 'Threshold'
 threshold34 = Threshold(Input=maskPoints1)
 threshold34.Scalars = ["POINTS", "treeID"]
-ThresholdBetween(threshold34, 12.0, 14.0)
+threshold34.ThresholdMethod = "Between"
+threshold34.LowerThreshold = 12.0
+threshold34.UpperThreshold = 14.0
 
 # save the output
 SaveData("MDS_trees.csv", threshold33)

--- a/python/morseMolecule.py
+++ b/python/morseMolecule.py
@@ -1,19 +1,5 @@
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility =======================================================
-
 # create a new 'XML Image Data Reader'
 builtInExamplevti = XMLImageDataReader(FileName=["BuiltInExample2.vti"])
 
@@ -34,17 +20,23 @@ tTKIcospheresFromPoints2.Radius = 3.0
 # Then select critical points of CellDimension 3 using 'Threshold' to select maxima
 threshold3 = Threshold(Input=tTKIcospheresFromPoints2)
 threshold3.Scalars = ["POINTS", "CellDimension"]
-ThresholdBetween(threshold3, 3.0, 3.0)
+threshold3.ThresholdMethod = "Between"
+threshold3.LowerThreshold = 3.0
+threshold3.UpperThreshold = 3.0
 
 # create a new 'Threshold'
 threshold1 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 1))
 threshold1.Scalars = ["CELLS", "NumberOfCriticalPointsOnBoundary"]
-ThresholdBetween(threshold1, 0.0, 0.0)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.0
+threshold1.UpperThreshold = 0.0
 
 # create a new 'Threshold'
 threshold2 = Threshold(Input=threshold1)
 threshold2.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold2, 2.0, 2.0)
+threshold2.ThresholdMethod = "Between"
+threshold2.LowerThreshold = 2.0
+threshold2.UpperThreshold = 2.0
 
 # create a new 'TTK GeometrySmoother'
 tTKGeometrySmoother1 = TTKGeometrySmoother(Input=threshold2)
@@ -64,22 +56,30 @@ tube1.Radius = 1.25
 # create a new 'Threshold'
 threshold8 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 1))
 threshold8.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold8, 1.0, 1.0)
+threshold8.ThresholdMethod = "Between"
+threshold8.LowerThreshold = 1.0
+threshold8.UpperThreshold = 1.0
 
 # create a new 'Threshold'
 threshold9 = Threshold(Input=threshold8)
 threshold9.Scalars = ["CELLS", "NumberOfCriticalPointsOnBoundary"]
-ThresholdBetween(threshold9, 1.0, 1.0)
+threshold9.ThresholdMethod = "Between"
+threshold9.LowerThreshold = 1.0
+threshold9.UpperThreshold = 1.0
 
 # create a new 'Threshold'
 threshold11 = Threshold(Input=threshold9)
 threshold11.Scalars = ["CELLS", "SeparatrixId"]
-ThresholdBetween(threshold11, 75.0, 76.0)
+threshold11.ThresholdMethod = "Between"
+threshold11.LowerThreshold = 75.0
+threshold11.UpperThreshold = 76.0
 
 # create a new 'Threshold'
 threshold10 = Threshold(Input=threshold9)
 threshold10.Scalars = ["CELLS", "SeparatrixId"]
-ThresholdBetween(threshold10, 73.0, 74.0)
+threshold10.ThresholdMethod = "Between"
+threshold10.LowerThreshold = 73.0
+threshold10.UpperThreshold = 74.0
 
 # create a new 'Append Datasets'
 appendDatasets1 = AppendDatasets(Input=[threshold10, threshold11])
@@ -102,7 +102,9 @@ tube2.Radius = 0.75
 # create a new 'Threshold'
 threshold4 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 2))
 threshold4.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold4, 1.0, 1.0)
+threshold4.ThresholdMethod = "Between"
+threshold4.LowerThreshold = 1.0
+threshold4.UpperThreshold = 1.0
 
 # create a new 'Clean to Grid'
 cleantoGrid2 = CleantoGrid(Input=threshold4)
@@ -120,17 +122,23 @@ tTKGeometrySmoother2.IterationNumber = 20
 # select 2-separatrices using 'Threshold'
 threshold5 = Threshold(Input=OutputPort(tTKMorseSmaleComplex1, 2))
 threshold5.Scalars = ["CELLS", "SeparatrixType"]
-ThresholdBetween(threshold5, 2.0, 2.0)
+threshold5.ThresholdMethod = "Between"
+threshold5.LowerThreshold = 2.0
+threshold5.UpperThreshold = 2.0
 
 # create a new 'Threshold'
 threshold6 = Threshold(Input=threshold5)
 threshold6.Scalars = ["CELLS", "NumberOfCriticalPointsOnBoundary"]
-ThresholdBetween(threshold6, 4.0, 4.0)
+threshold6.ThresholdMethod = "Between"
+threshold6.LowerThreshold = 4.0
+threshold6.UpperThreshold = 4.0
 
 # select a particular 2-separatrix using 'Threshold'
 threshold7 = Threshold(Input=threshold6)
 threshold7.Scalars = ["CELLS", "SeparatrixId"]
-ThresholdBetween(threshold7, 2.0, 2.0)
+threshold7.ThresholdMethod = "Between"
+threshold7.LowerThreshold = 2.0
+threshold7.UpperThreshold = 2.0
 
 # create a new 'Clean to Grid'
 cleantoGrid3 = CleantoGrid(Input=threshold7)

--- a/python/morsePersistence.py
+++ b/python/morsePersistence.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'Plane'
 plane1 = Plane()
 plane1.XResolution = 300
@@ -69,12 +55,16 @@ tTKPersistenceCurve1 = TTKPersistenceCurve(Input=tTKPersistenceDiagram1)
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, 0.0, 100000.0)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.0
+threshold1.UpperThreshold = 100000.0
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=threshold1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 0.7, 10000.0)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 0.7
+persistenceThreshold.UpperThreshold = 10000.0
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/morseSmaleQuadrangulation.py
+++ b/python/morseSmaleQuadrangulation.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Unstructured Grid Reader'
 rockerArmvtu = XMLUnstructuredGridReader(FileName=["rockerArm.vtu"])
 
@@ -37,7 +23,9 @@ tTKPersistenceDiagram1.IgnoreBoundary = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(threshold1, 0.001, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 0.001
+threshold1.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/persistenceClustering0.py
+++ b/python/persistenceClustering0.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 clustering0csv = CSVReader(FileName=["clustering0.csv"])
 
@@ -47,7 +33,9 @@ tTKPersistenceDiagram1.IgnoreBoundary = False
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=tTKPersistenceDiagram1)
 persistenceThreshold0.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold0, 10.0, 999999999)
+persistenceThreshold0.ThresholdMethod = "Between"
+persistenceThreshold0.LowerThreshold = 10.0
+persistenceThreshold0.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/persistenceClustering1.py
+++ b/python/persistenceClustering1.py
@@ -1,19 +1,5 @@
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 clusteringcsv = CSVReader(FileName=["clustering1.csv"])
 
@@ -45,12 +31,16 @@ tTKPersistenceDiagram1.IgnoreBoundary = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=threshold1)
 persistenceThreshold0.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold0, 10.0, 999999999)
+persistenceThreshold0.ThresholdMethod = "Between"
+persistenceThreshold0.LowerThreshold = 10.0
+persistenceThreshold0.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/persistenceClustering2.py
+++ b/python/persistenceClustering2.py
@@ -1,19 +1,5 @@
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 clusteringcsv = CSVReader(FileName=["clustering2.csv"])
 
@@ -46,12 +32,16 @@ tTKPersistenceDiagram1.IgnoreBoundary = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=threshold1)
 persistenceThreshold0.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold0, 5.0, 999999999)
+persistenceThreshold0.ThresholdMethod = "Between"
+persistenceThreshold0.LowerThreshold = 5.0
+persistenceThreshold0.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/persistenceClustering3.py
+++ b/python/persistenceClustering3.py
@@ -1,19 +1,5 @@
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 clusteringcsv = CSVReader(FileName=["clustering3.csv"])
 
@@ -45,12 +31,16 @@ tTKPersistenceDiagram1.IgnoreBoundary = False
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=threshold1)
 persistenceThreshold0.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold0, 10.0, 999999999)
+persistenceThreshold0.ThresholdMethod = "Between"
+persistenceThreshold0.LowerThreshold = 10.0
+persistenceThreshold0.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/persistenceClustering4.py
+++ b/python/persistenceClustering4.py
@@ -1,19 +1,5 @@
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'CSV Reader'
 clusteringcsv = CSVReader(FileName=["clustering4.csv"])
 
@@ -44,12 +30,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "SplatterValues"]
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold0 = Threshold(Input=threshold1)
 persistenceThreshold0.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold0, 10.0, 999999999)
+persistenceThreshold0.ThresholdMethod = "Between"
+persistenceThreshold0.LowerThreshold = 10.0
+persistenceThreshold0.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/tectonicPuzzle.py
+++ b/python/tectonicPuzzle.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Unstructured Grid Reader'
 tectonicPuzzlevtu = XMLUnstructuredGridReader(FileName=["tectonicPuzzle.vtu"])
 
@@ -34,7 +20,9 @@ connectivity1 = Connectivity(Input=tetrahedralize1)
 # create a new 'Threshold'
 threshold1 = Threshold(Input=connectivity1)
 threshold1.Scalars = ["POINTS", "RegionId"]
-ThresholdBetween(threshold1, 1.0, 1.0)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = 1.0
+threshold1.UpperThreshold = 1.0
 
 # create a new 'Calculator'
 calculator1 = Calculator(Input=threshold1)
@@ -48,12 +36,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "logViscosity"]
 # create a new 'Threshold'
 threshold2 = Threshold(Input=tTKPersistenceDiagram1)
 threshold2.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold2, -0.1, 999999999)
+threshold2.ThresholdMethod = "Between"
+threshold2.LowerThreshold = -0.1
+threshold2.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=threshold2)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 0.5, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 0.5
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK IcospheresFromPoints'
 tTKIcospheresFromPoints1 = TTKIcospheresFromPoints(Input=persistenceThreshold)
@@ -76,12 +68,16 @@ tTKIcospheresFromPoints2.Radius = 0.1
 # create a new 'Threshold'
 threshold3 = Threshold(Input=tTKIcospheresFromPoints2)
 threshold3.Scalars = ["POINTS", "CellDimension"]
-ThresholdBetween(threshold3, 2.0, 2.0)
+threshold3.ThresholdMethod = "Between"
+threshold3.LowerThreshold = 2.0
+threshold3.UpperThreshold = 2.0
 
 # create a new 'Threshold'
 lARGE_MAXIMA_THRESHOLD = Threshold(Input=threshold3)
 lARGE_MAXIMA_THRESHOLD.Scalars = ["POINTS", "ManifoldSize"]
-ThresholdBetween(lARGE_MAXIMA_THRESHOLD, 75.0, 999999999)
+lARGE_MAXIMA_THRESHOLD.ThresholdMethod = "Between"
+lARGE_MAXIMA_THRESHOLD.LowerThreshold = 75.0
+lARGE_MAXIMA_THRESHOLD.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 pERSISTENT_MINIMA = Threshold(Input=tTKIcospheresFromPoints1)
@@ -105,12 +101,16 @@ tTKPersistenceDiagram2.ScalarField = ["POINTS", "logViscosity"]
 # create a new 'Threshold'
 threshold4 = Threshold(Input=tTKPersistenceDiagram2)
 threshold4.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold4, -0.1, 999999999)
+threshold4.ThresholdMethod = "Between"
+threshold4.LowerThreshold = -0.1
+threshold4.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 threshold5 = Threshold(Input=threshold4)
 threshold5.Scalars = ["CELLS", "PairType"]
-ThresholdBetween(threshold5, 1.0, 1.0)
+threshold5.ThresholdMethod = "Between"
+threshold5.LowerThreshold = 1.0
+threshold5.UpperThreshold = 1.0
 
 # create a new 'Calculator'
 calculator2 = Calculator(Input=threshold5)
@@ -120,7 +120,9 @@ calculator2.Function = "coordsX"
 # create a new 'Threshold'
 sADDLE_VALUE_THRESHOLD = Threshold(Input=calculator2)
 sADDLE_VALUE_THRESHOLD.Scalars = ["POINTS", "SaddleValue"]
-ThresholdBetween(sADDLE_VALUE_THRESHOLD, -0.2, 1.75)
+sADDLE_VALUE_THRESHOLD.ThresholdMethod = "Between"
+sADDLE_VALUE_THRESHOLD.LowerThreshold = -0.2
+sADDLE_VALUE_THRESHOLD.UpperThreshold = 1.75
 
 # create a new 'TTK IcospheresFromPoints'
 tTKIcospheresFromPoints3 = TTKIcospheresFromPoints(Input=sADDLE_VALUE_THRESHOLD)
@@ -129,7 +131,9 @@ tTKIcospheresFromPoints3.Radius = 0.5
 # create a new 'Threshold'
 lARGE_MAXIMA_LOW_SADDLE = Threshold(Input=tTKIcospheresFromPoints3)
 lARGE_MAXIMA_LOW_SADDLE.Scalars = ["POINTS", "CriticalType"]
-ThresholdBetween(lARGE_MAXIMA_LOW_SADDLE, 3.0, 3.0)
+lARGE_MAXIMA_LOW_SADDLE.ThresholdMethod = "Between"
+lARGE_MAXIMA_LOW_SADDLE.LowerThreshold = 3.0
+lARGE_MAXIMA_LOW_SADDLE.UpperThreshold = 3.0
 
 # create a new 'Append Datasets'
 lARGE_MAXIMA_LOW_SADDLE_AND_PERSISTENT_MINIMA = AppendDatasets(

--- a/python/tribute.py
+++ b/python/tribute.py
@@ -1,20 +1,6 @@
 #!/usr/bin/env python
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'PNG Series Reader'
 tributepng = PNGSeriesReader(FileNames=["tribute.png"])
 
@@ -30,12 +16,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "originalData"]
 # create a new 'Threshold'
 threshold1 = Threshold(Input=tTKPersistenceDiagram1)
 threshold1.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold1, -0.1, 999999999)
+threshold1.ThresholdMethod = "Between"
+threshold1.LowerThreshold = -0.1
+threshold1.UpperThreshold = 999999999
 
 # create a new 'Threshold'
 minimumPairs = Threshold(Input=threshold1)
 minimumPairs.Scalars = ["CELLS", "PairType"]
-ThresholdBetween(minimumPairs, -1.0, 0.0)
+minimumPairs.ThresholdMethod = "Between"
+minimumPairs.LowerThreshold = -1.0
+minimumPairs.UpperThreshold = 0.0
 
 # create a new 'Calculator'
 calculator6 = Calculator(Input=minimumPairs)
@@ -62,7 +52,9 @@ appendDatasets1 = AppendDatasets(Input=[deathThreshold, maximumPairs])
 # create a new 'Threshold'
 persistenceThreshold = Threshold(Input=appendDatasets1)
 persistenceThreshold.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold, 8.5, 999999999)
+persistenceThreshold.ThresholdMethod = "Between"
+persistenceThreshold.LowerThreshold = 8.5
+persistenceThreshold.UpperThreshold = 999999999
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(

--- a/python/uncertainStartingVortex.py
+++ b/python/uncertainStartingVortex.py
@@ -2,20 +2,6 @@
 
 from paraview.simple import *
 
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
-
 # create a new 'XML Image Data Reader'
 uncertainStartingVortexvti = XMLImageDataReader(
     FileName=["uncertainStartingVortex.vti"]
@@ -32,12 +18,16 @@ tTKMandatoryCriticalPoints1.NormalizedThreshold = 0.02
 # create a new 'Threshold' for the Minimas
 threshold6 = Threshold(Input=tTKMandatoryCriticalPoints1)
 threshold6.Scalars = ["POINTS", "MinimumComponents"]
-ThresholdBetween(threshold6, 0.0, 2.0)
+threshold6.ThresholdMethod = "Between"
+threshold6.LowerThreshold = 0.0
+threshold6.UpperThreshold = 2.0
 
 # create a new 'Threshold' for the maximas
 threshold5 = Threshold(Input=OutputPort(tTKMandatoryCriticalPoints1, 3))
 threshold5.Scalars = ["POINTS", "MaximumComponents"]
-ThresholdBetween(threshold5, 0.0, 8.0)
+threshold5.ThresholdMethod = "Between"
+threshold5.LowerThreshold = 0.0
+threshold5.UpperThreshold = 8.0
 
 # create a new 'Random Attributes'
 randomAttributes1 = RandomAttributes(Input=uncertainStartingVortexvti)
@@ -59,12 +49,16 @@ tTKPersistenceDiagram1.ScalarField = ["POINTS", "realization0"]
 # create a new 'Threshold'
 threshold2 = Threshold(Input=tTKPersistenceDiagram1)
 threshold2.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(threshold2, 0.0, 185374.0)
+threshold2.ThresholdMethod = "Between"
+threshold2.LowerThreshold = 0.0
+threshold2.UpperThreshold = 185374.0
 
 # create a new 'Threshold'
 persistenceThreshold1 = Threshold(Input=threshold2)
 persistenceThreshold1.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistenceThreshold1, 0.05, 1.75475390406744)
+persistenceThreshold1.ThresholdMethod = "Between"
+persistenceThreshold1.LowerThreshold = 0.05
+persistenceThreshold1.UpperThreshold = 1.75475390406744
 
 # create a new 'TTK TopologicalSimplification'
 tTKTopologicalSimplification1 = TTKTopologicalSimplification(


### PR DESCRIPTION
This PR removes the `ThresholdBetween` compatibility method in the Python scripts displayed in the TTK Examples website.
The ParaView 3.10 (and above) version has been preferred for upward compatibility.

Enjoy,
Pierre