### PR TITLE
Force absolute simplification threshold

### DIFF
--- a/python/2manifoldLearning.py
+++ b/python/2manifoldLearning.py
@@ -46,6 +46,7 @@ tTKMorseSmaleComplex1.ScalarField = ["POINTS", "SplatterValues"]
 tTKMorseSmaleComplex1.Ascending2Separatrices = 1
 tTKMorseSmaleComplex1.ReturnSaddleConnectors = 1
 tTKMorseSmaleComplex1.SaddleConnectorsPersistenceThreshold = 0.01
+tTKMorseSmaleComplex1.ThresholdIsAbsolute = True
 
 # create a new 'Tetrahedralize'
 tetrahedralize1 = Tetrahedralize(Input=OutputPort(tTKMorseSmaleComplex1, 2))

--- a/python/contourTreeAlignment.py
+++ b/python/contourTreeAlignment.py
@@ -20,6 +20,7 @@ ttkTopologicalSimplificationByPersistence = TTKTopologicalSimplificationByPersis
 )
 ttkTopologicalSimplificationByPersistence.InputArray = ["POINTS", "nrrd"]
 ttkTopologicalSimplificationByPersistence.PersistenceThreshold = 0.05
+ttkTopologicalSimplificationByPersistence.ThresholdIsAbsolute = True
 
 # create a new 'TTK Merge and Contour Tree (FTM)'
 ttkMergeandContourTreeFTM = TTKMergeandContourTreeFTM(

--- a/states/2manifoldLearning.pvsm
+++ b/states/2manifoldLearning.pvsm
@@ -37654,6 +37654,10 @@
         <Element index="0" value="1"/>
         <Domain name="bool" id="10790.ReturnSaddleConnectors.bool"/>
       </Property>
+      <Property name="ThresholdIsAbsolute" id="10790.ThresholdIsAbsolute" number_of_elements="1">
+        <Element index="0" value="1"/>
+        <Domain name="bool" id="10790.ThresholdIsAbsolute.bool"/>
+      </Property>
       <Property name="SaddleConnectorsPersistenceThreshold" id="10790.SaddleConnectorsPersistenceThreshold" number_of_elements="1">
         <Element index="0" value="0.01"/>
         <Domain name="range" id="10790.SaddleConnectorsPersistenceThreshold.range"/>

--- a/states/persistentGenerators_darkSky.pvsm
+++ b/states/persistentGenerators_darkSky.pvsm
@@ -35924,6 +35924,10 @@
         <Element index="0" value="0.01"/>
         <Domain name="range" id="17874.SaddleConnectorsPersistenceThreshold.range"/>
       </Property>
+      <Property name="ThresholdIsAbsolute" id="17874.ThresholdIsAbsolute" number_of_elements="1">
+        <Element index="0" value="1"/>
+        <Domain name="bool" id="17874.ThresholdIsAbsolute.bool"/>
+      </Property>
       <Property name="Scalar Field" id="17874.Scalar Field" number_of_elements="5">
         <Element index="0" value="0"/>
         <Element index="1" value=""/>


### PR DESCRIPTION
In https://github.com/topology-tool-kit/ttk/commit/0add7302de82fbc8d8041994bdd399f1f50bb5cf, the simplification threshold in `ToplogicalSimplificationByPersistence` and `MorseSmaleComplex` became relative by default (previously absolute).

This PR forces the threshold to be absolute in relevant state files and Python script.

Enjoy,
Pierre