### PR TITLE
[MergeTreeTemporalReduction] rename encoding

### DIFF
--- a/docs/mergeTreeTemporalReduction.md
+++ b/docs/mergeTreeTemporalReduction.md
@@ -6,7 +6,7 @@
 This example first loads an ensemble of scalar fields inside a cinema database from disk.
 Then, the [Split Tree](https://topology-tool-kit.github.io/doc/html/classttkFTMTree.html) is computed on each scalar field.
 
-All these trees are passed to [MergeTreeTemporalReductionEncoding](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeTemporalReductionEncoding.html) to compute a subsampling of a sequence of merge trees. The algorithm greedily removes trees in the sequence that can be accurately reconstructed by the geodesic computation. The remaining trees are called the key frames.
+All these trees are passed to [MergeTreeTemporalReduction](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeTemporalReduction.html) to compute a subsampling of a sequence of merge trees. The algorithm greedily removes trees in the sequence that can be accurately reconstructed by the geodesic computation. The remaining trees are called the key frames.
 
 In terms of visualisation, the three key frames trees and two reconstructed trees are visualized with a planar layout along with their corresponding scalar fields.
 
@@ -44,5 +44,5 @@ pvpython python/mergeTreeTemporalReduction.py
 
 [FTMTree](https://topology-tool-kit.github.io/doc/html/classttkFTMTree.html)
 
-[MergeTreeTemporalReductionEncoding](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeTemporalReductionEncoding.html)
+[MergeTreeTemporalReduction](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeTemporalReduction.html)
 

--- a/python/mergeTreeTemporalReduction.py
+++ b/python/mergeTreeTemporalReduction.py
@@ -23,16 +23,12 @@ all_MT = GroupDatasets(
     ]
 )
 
-# create a new 'TTK MergeTreeTemporalReductionEncoding'
-tTKMergeTreeTemporalReductionEncoding1 = TTKMergeTreeTemporalReductionEncoding(
-    Input=all_MT
-)
-tTKMergeTreeTemporalReductionEncoding1.RemovalPercentage = 75.0
-tTKMergeTreeTemporalReductionEncoding1.Epsilon1 = 0.0
-tTKMergeTreeTemporalReductionEncoding1.Epsilon2 = 100.0
-tTKMergeTreeTemporalReductionEncoding1.Epsilon3 = 100.0
-tTKMergeTreeTemporalReductionEncoding1.PersistenceThreshold = 3.0
+# create a new 'TTK MergeTreeTemporalReduction'
+tTKMergeTreeTemporalReduction1 = TTKMergeTreeTemporalReduction(Input=all_MT)
+tTKMergeTreeTemporalReduction1.RemovalPercentage = 75.0
+tTKMergeTreeTemporalReduction1.Epsilon1 = 0.0
+tTKMergeTreeTemporalReduction1.Epsilon2 = 100.0
+tTKMergeTreeTemporalReduction1.Epsilon3 = 100.0
+tTKMergeTreeTemporalReduction1.PersistenceThreshold = 3.0
 
-SaveData(
-    "ReductionCoefficients.csv", OutputPort(tTKMergeTreeTemporalReductionEncoding1, 1)
-)
+SaveData("ReductionCoefficients.csv", OutputPort(tTKMergeTreeTemporalReduction1, 1))


### PR DESCRIPTION
This PR fixes the use of the `MergeTreeTemporalReductionEncoding` filter in the corresponding state.
(Following PR of topology-tool-kit/ttk#975)