### PR TITLE
[MT-PGA] fix doc

### DIFF
--- a/docs/mergeTreePGA.md
+++ b/docs/mergeTreePGA.md
@@ -9,7 +9,7 @@ Then, the [MergeTree](https://topology-tool-kit.github.io/doc/html/classttkMerge
 
 All these trees are passed to [MergeTreePrincipalGeodesics](https://topology-tool-kit.github.io/doc/html/classttkMergeTreePrincipalGeodesics.html) to compute principal geodesic analysis in the metric space of merge trees. 
 
-Then the filter [MergeTreePrincipalGeodesicsDecoding](https://topology-tool-kit.github.io/doc/html/classttkMergeTreePrincipalGeodesics.html) is used to reconstruct the input trees, to sample evenly trees along the principal geodesics and to sample a discrete grid of merge trees of the PGA basis. 
+Then the filter [MergeTreePrincipalGeodesicsDecoding](https://topology-tool-kit.github.io/doc/html/classttkMergeTreePrincipalGeodesicsDecoding.html) is used to reconstruct the input trees, to sample evenly trees along the principal geodesics and to sample a discrete grid of merge trees of the PGA basis.
 
 A distance matrix is then computed with [MergeTreeDistanceMatrix](https://topology-tool-kit.github.io/doc/html/classttkMergeTreeDistanceMatrix.html) with the trees of the grid. This distance matrix is used as input of [DimensionReduction](https://topology-tool-kit.github.io/doc/html/classttkDimensionReduction.html) to compute a MultiDimensional Scaling (MDS), performing a dimensionality reduction in 3D (and 2D with a second DimensionReduction filter) respecting the most the input distance matrix. 
 
@@ -43,6 +43,8 @@ pvpython python/mergeTreePGA.py
 
 ## Outputs
 -  `MT-PGA_coef.csv`: the coefficients of the input trees corresponding to their coordinates in the PGA basis.
+-  `MT-PGA_geodesics.csv`: the geodesics of the PGA basis.
+-  `MT-PGA_reconstructed_trees.vtm`: the reconstructed input trees.
 
 
 ## C++/Python API


### PR DESCRIPTION
This PR fixes the doc of MT-PGA:
- fix the link of MergeTreePrincipalGeodesicsDecoding.
- fix the description of the output of the python script.